### PR TITLE
Updated previously known Actor* 0xA4

### DIFF
--- a/obse/obse/GameObjects.h
+++ b/obse/obse/GameObjects.h
@@ -847,6 +847,7 @@ public:
 	ActorValues		avModifiers;					// 088
 	PowerListEntry  greaterPowerList;				// 09C
 	DispositionModifier * dispositionModifier;      // 0A4 - This is created after the player has increased/decreased the Actor's disposition
+	UInt32          unk0A8;                         // 0A8	
 	float			unk0AC;							// 0AC
 	UInt32			DeadState;						// 0B0
 	UInt32			unk0B4[(0x0CC - 0x0B4) >> 2];	// 0B4

--- a/obse/obse/GameObjects.h
+++ b/obse/obse/GameObjects.h
@@ -831,17 +831,10 @@ public:
 	};
 
 	// 8
-	struct Unk0A4
+	struct DispositionModifier
 	{
-		// 8+
-		struct Data
-		{
-			UInt32	unk0;
-			Actor	* unk4;
-		};
-
-		Data	* data;
-		Unk0A4	* next;
+		SInt32			  modifier;					// 00 - Can be positive or negative. Linear based on previous interactions
+		TESObjectREFR	* refr;						// 04 - This is always the player
 	};
 
 	// bases
@@ -853,7 +846,7 @@ public:
 	UInt32			unk080[(0x088 - 0x080) >> 2];	// 080
 	ActorValues		avModifiers;					// 088
 	PowerListEntry  greaterPowerList;				// 09C
-	Unk0A4			unk0A4;							// 0A4
+	DispositionModifier * dispositionModifier;      // 0A4 - This is created after the player has increased/decreased the Actor's disposition
 	float			unk0AC;							// 0AC
 	UInt32			DeadState;						// 0B0
 	UInt32			unk0B4[(0x0CC - 0x0B4) >> 2];	// 0B4


### PR DESCRIPTION
Heya,

I have been doing a lot of reversing and am going to start creating PRs with those changes. I tried to clean them up and make them as presentable as possible.

**Changes**
GameObjects.h - Actor*

Previously Unk04 was a structor but I have come to realize that it is a pointer to the disposition modifier. The game will check A4* to see if it has been instantiated and if it has then it will grab both the refr and the modifier. It then does an addition on the base formula for that modifier. The modifier can be negative or positive and is the offset from the speechcraft formula calcuation. So if they have a base disposition of 38 and a modifier of 22 then the Actor will have a final disposition of 60.

**Save Relation**
This modifier is saved into the game save.