### PR TITLE
Refactor compiler error/warning handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+﻿################################################################################
+# This .gitignore file was automatically created by Microsoft(R) Visual Studio.
+################################################################################
+
+/common/Debug
+/common/Release
+/obse/.vs
+/obse/obse/Debug 1_2_0_416
+/obse/obse_editor/Debug 1_2_0_0

--- a/obse/obse/Settings.cpp
+++ b/obse/obse/Settings.cpp
@@ -4,6 +4,7 @@
 UInt8 installCrashdump;
 UInt8 warningUnquotedString;
 UInt8 warningUDFRefVar;
+UInt8 warningDeprecatedCmd;
 bool FreeRef;
 bool NoisyTestExpr;
 
@@ -20,6 +21,7 @@ bool InitializeSettings() {
 	installCrashdump = GetPrivateProfileInt(INI_SECTION_RUNTIME, INI_RUNTIME_CRASHDUMP, 0, s_configPath.c_str());
 	warningUDFRefVar = GetPrivateProfileInt(INI_SECTION_COMPILER, INI_COMPILER_WARNFUNCTPTR, 1, s_configPath.c_str());
 	warningUnquotedString = GetPrivateProfileInt(INI_SECTION_COMPILER, INI_COMPILER_WARNUNQUOTEDSTRING, 1, s_configPath.c_str());
+	warningDeprecatedCmd = GetPrivateProfileInt(INI_SECTION_COMPILER, INI_COMPILER_WARNDEPRECATEDCMD, 1, s_configPath.c_str());
 	FreeRef = GetPrivateProfileInt(INI_SECTION_RUNTIME, "bDeallocateReferences", 0, s_configPath.c_str());
 	NoisyTestExpr = GetPrivateProfileInt(INI_SECTION_RUNTIME, "bTestExprComplainsOnError", 0, s_configPath.c_str());
 

--- a/obse/obse/Settings.h
+++ b/obse/obse/Settings.h
@@ -6,6 +6,7 @@
 #define INI_SECTION_COMPILER		"Compiler"
 #define INI_COMPILER_WARNUNQUOTEDSTRING		"bWarningUnquotedString"
 #define INI_COMPILER_WARNFUNCTPTR			"bWarningUDFRefVar"
+#define INI_COMPILER_WARNDEPRECATEDCMD		"bWarningDeprecatedCommand"
 
 
 static std::string s_configPath;
@@ -13,6 +14,7 @@ static std::string s_configPath;
 extern UInt8 installCrashdump;
 extern UInt8 warningUnquotedString;
 extern UInt8 warningUDFRefVar;
+extern UInt8 warningDeprecatedCmd;
 extern bool FreeRef;
 extern bool NoisyTestExpr;
 

--- a/obse/obse/Utilities.cpp
+++ b/obse/obse/Utilities.cpp
@@ -566,46 +566,51 @@ void MakeLower(char* str)
 #pragma warning(pop)
 
 // ErrOutput
-ErrOutput::ErrOutput(_ShowError errorFunc, _ShowWarning warningFunc)
+ErrOutput::ErrOutput(ErrorCallbackT errorFunc, WarningCallbackT warningFunc)
 {
 	ShowWarning = warningFunc;
 	ShowError = errorFunc;
 }
 
-void ErrOutput::vShow(ErrOutput::Message& msg, va_list args)
+void ErrOutput::vShow(ErrOutput::Message& msg, void* userData, va_list args)
 {
-	char msgText[0x400];
+	char msgText[0x1000];
 	vsprintf_s(msgText, sizeof(msgText), msg.fmt.c_str(), args);
 	if (msg.CanDisable())
 	{
 		if (msg.IsDisabled() == false)
-			if (ShowWarning(msgText))
+			if (ShowWarning(msgText, userData))
 				msg.SetDisabled();
 	}
 	else
-		ShowError(msgText);
+		ShowError(msgText, userData);
 }
 
-void ErrOutput::Show(ErrOutput::Message msg, ...)
+void ErrOutput::Show(ErrOutput::Message msg, void* userData, ...)
 {
 	va_list args;
-	va_start(args, msg);
+	va_start(args, userData);
 
-	vShow(msg, args);
+	vShow(msg, userData, args);
+
+	va_end(args);
 }
 
-void ErrOutput::Show(const char* msg, ...)
+void ErrOutput::Show(const char* msg, void* userData, ...)
 {
 	va_list args;
-	va_start(args, msg);
+	va_start(args, userData);
 
-	vShow(msg, args);
+	vShow(msg, userData, args);
+
+	va_end(args);
+
 }
 
-void ErrOutput::vShow(const char* msg, va_list args)
+void ErrOutput::vShow(const char* msg, void* userData, va_list args)
 {
 	Message tempMsg (msg);
-	vShow(tempMsg, args);
+	vShow(tempMsg, userData, args);
 }
 
 LPTOP_LEVEL_EXCEPTION_FILTER g_OriginalTopLevelExceptionFilter = NULL;

--- a/obse/obse/Utilities.h
+++ b/obse/obse/Utilities.h
@@ -323,19 +323,17 @@ void MakeLower(char* str);
 // data between obse and plugins
 char* CopyCString(const char* src);
 
-//extern UInt8  isWarning;
-extern UInt8 block;   //TODO reimplement the generic system
 // Generic error/warning output
 // provides a common way to output errors and warnings
 class ErrOutput
 {
-	typedef void (* _ShowError)(const char* msg);
-	typedef bool (* _ShowWarning)(const char* msg);		// returns true if user requests to disable warning
+	using ErrorCallbackT = std::function<void(const char* msg, void* userData)>;
+	using WarningCallbackT = std::function<bool(const char* msg, void* userData)>;	// returns true if user requests to disable warning
 
-	_ShowError		ShowError;
-	_ShowWarning	ShowWarning;
+	ErrorCallbackT		ShowError;
+	WarningCallbackT	ShowWarning;
 public:
-	ErrOutput(_ShowError errorFunc, _ShowWarning warningFunc);
+	ErrOutput(ErrorCallbackT errorFunc, WarningCallbackT warningFunc);
 
 	struct Message
 	{
@@ -358,10 +356,10 @@ public:
 		void SetDisabled () { flags |= kFlag_Disabled; }
 	};
 
-	void Show(Message msg, ...);
-	void Show(const char* msg, ...);
-	void vShow(Message& msg, va_list args);
-	void vShow(const char* msg, va_list args);
+	void Show(Message msg, void* userData = nullptr, ...);
+	void Show(const char* msg, void* userData = nullptr, ...);
+	void vShow(Message& msg, void* userData, va_list args);
+	void vShow(const char* msg, void* userData, va_list args);
 };
 
 inline Vector2 Vector2_Subtract(Vector2& lhs, Vector2& rhs)

--- a/obse/obse_editor/obse_editor.vcxproj.user
+++ b/obse/obse_editor/obse_editor.vcxproj.user
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release 1_2_0_0|Win32'">
-    <LocalDebuggerCommand>$(OblivionPath)TESConstructionSet.exe</LocalDebuggerCommand>
+    <LocalDebuggerCommand>$(OblivionPath)\TESConstructionSet.exe</LocalDebuggerCommand>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release 1_2_0_0|Win32'">
     <LocalDebuggerWorkingDirectory>$(OblivionPath)</LocalDebuggerWorkingDirectory>
@@ -11,7 +11,7 @@
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug 1_2_0_0|Win32'">
-    <LocalDebuggerCommand>$(OblivionPath)TESConstructionSet.exe</LocalDebuggerCommand>
+    <LocalDebuggerCommand>$(OblivionPath)\TESConstructionSet.exe</LocalDebuggerCommand>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug 1_2_0_0|Win32'">
     <LocalDebuggerWorkingDirectory>$(OblivionPath)</LocalDebuggerWorkingDirectory>

--- a/obse/obse_vs10.sln
+++ b/obse/obse_vs10.sln
@@ -14,16 +14,6 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "loader_common", "loader_com
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "steam_loader", "steam_loader\steam_loader.vcxproj", "{0B4878C9-13C0-45F2-A25D-F532EC19760A}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Misc", "Misc", "{399E8DD8-D7C5-42A0-B72D-A34B3183134F}"
-	ProjectSection(SolutionItems) = preProject
-		obse.ini = obse.ini
-		obse_command_doc.html = obse_command_doc.html
-		obse_readme.txt = obse_readme.txt
-		obse_whatsnew.txt = obse_whatsnew.txt
-		plugin_opcode_assignments.txt = plugin_opcode_assignments.txt
-		Todo.txt = Todo.txt
-	EndProjectSection
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Win32 = Debug|Win32


### PR DESCRIPTION
Integrate the command deprecation warning to the existing error/warning output code. Defers handling to the CSE when possible. No additional hooks necessary.