### PR TITLE
Fix an issue with SetMenuStringValue / MessageBoxEX / TextInputMessageBox

### DIFF
--- a/obse/obse/Commands_Game.cpp
+++ b/obse/obse/Commands_Game.cpp
@@ -18,6 +18,7 @@
 #include "obse_common/SafeWrite.h"
 #include "NiObjects.h"
 #include <obse/NiAPI.h>
+#include <mbstring.h>
 
 // first character in name mapped to type ID
 //	b	0
@@ -415,14 +416,23 @@ static bool Cmd_MessageBoxEX_Execute(COMMAND_ARGS)
 	//extract the buttons
 	const char* b[10] = {0};
 	UInt32 btnIdx = 0;
+	short mb_length = 0;
 
 	for (char* ch = buffer; *ch && btnIdx < 10; ch++)
 	{
-		if (*ch == GetSeparatorChar(scriptObj))
+		if (strlen(ch) > 1 && mb_length == 0) {
+			if (_mbsbtype((const unsigned char*)(ch), 1) == 2)		// get the length of a multibyte character from its first byte.
+				mb_length = _mbclen((const unsigned char*)(ch));
+		}
+
+		if (*ch == GetSeparatorChar(scriptObj) && mb_length == 0)		// bytes in multibyte characters are not considered as SeparatorChar
 		{
 			*ch = '\0';
 			b[btnIdx++] = ch + 1;
 		}
+
+		if (mb_length > 0)
+			mb_length--;
 	}
 
 	if (!btnIdx)				//supply default OK button

--- a/obse/obse/Commands_Game.cpp
+++ b/obse/obse/Commands_Game.cpp
@@ -416,23 +416,24 @@ static bool Cmd_MessageBoxEX_Execute(COMMAND_ARGS)
 	//extract the buttons
 	const char* b[10] = {0};
 	UInt32 btnIdx = 0;
-	short mb_length = 0;
+	UInt32 mb_length = 0;
 
 	for (char* ch = buffer; *ch && btnIdx < 10; ch++)
 	{
-		if (strlen(ch) > 1 && mb_length == 0) {
-			if (_mbsbtype((const unsigned char*)(ch), 1) == 2)		// get the length of a multibyte character from its first byte.
-				mb_length = _mbclen((const unsigned char*)(ch));
+		if (mb_length > 0) {
+			mb_length--;
+			continue;		// bytes in multibyte characters are not considered as SeparatorChar
+		} else if (strlen(ch) > 1 && _mbsbtype((const unsigned char*)(ch), 1) == 2) {
+			mb_length = _mbclen((const unsigned char*)(ch)) - 1;		// get the length of a multibyte character from its first byte.
+			continue;
 		}
 
-		if (*ch == GetSeparatorChar(scriptObj) && mb_length == 0)		// bytes in multibyte characters are not considered as SeparatorChar
+		if (*ch == GetSeparatorChar(scriptObj))
 		{
 			*ch = '\0';
 			b[btnIdx++] = ch + 1;
 		}
 
-		if (mb_length > 0)
-			mb_length--;
 	}
 
 	if (!btnIdx)				//supply default OK button

--- a/obse/obse/Commands_Menu.cpp
+++ b/obse/obse/Commands_Menu.cpp
@@ -13,6 +13,7 @@
 #include "StringVar.h"
 #include "Hooks_Gameplay.h"
 #include "GameData.h"
+#include <mbstring.h>
 
 typedef void (* _CloseAllMenus)(void);
 
@@ -553,8 +554,9 @@ static bool GetSetMenuValue_Execute(COMMAND_ARGS, UInt32 mode)
 			bExtracted = ExtractFormatStringArgs(0, stringArg, paramInfo, arg1, opcodeOffsetPtr, scriptObj, eventList, kCommandInfo_GetMenuFloatValue.numParams, &menuType);
 			// extract new value from format string
 			char* context = NULL;
-			componentPath = strtok_s(stringArg, separatorChar, &context);
-			newStringVal = strtok_s(NULL, separatorChar, &context);
+			componentPath = (char*)(_mbstok_s((unsigned char*)stringArg, (const unsigned char*)separatorChar, (unsigned char**)&context));
+			newStringVal = (char*)(_mbstok_s(NULL, (const unsigned char*)separatorChar, (unsigned char**)&context));
+
 			bExtracted = (bExtracted && componentPath && newStringVal);
 		}
 		break;

--- a/obse/obse/Commands_TextInput.cpp
+++ b/obse/obse/Commands_TextInput.cpp
@@ -268,23 +268,25 @@ void TextInputMessageBox::Init()
 	UInt32 fmtStringLen = strlen(m_fmtString);
 	char* fmtString = new char[fmtStringLen + 1];
 	strcpy_s(fmtString, fmtStringLen + 1, m_fmtString);
-	short mb_length = 0;
+	UInt32 mb_length = 0;
 
 	//separate prompt text and button text
 	for (UInt32 strPos = 0; strPos < fmtStringLen && numButtons < 10; strPos++)
 	{
-		if (mb_length == 0) {
-			if (_mbsbtype((const unsigned char*)(fmtString + strPos), 1) == 2)		// get the length of a multibyte character from its first byte.
-				mb_length = _mbclen((const unsigned char*)(fmtString + strPos));
+		if (mb_length > 0) {
+			mb_length--;
+			continue;		// bytes in multibyte characters are not considered as SeparatorChar
+		} else if (_mbsbtype((const unsigned char*)(fmtString + strPos), 1) == 2) {
+			mb_length = _mbclen((const unsigned char*)(fmtString + strPos)) - 1;		// get the length of a multibyte character from its first byte.
+			continue;
 		}
 
-		if (fmtString[strPos] == GetSeparatorChar(m_script) && (strPos + 1 < fmtStringLen) && mb_length == 0)
+
+		if (fmtString[strPos] == GetSeparatorChar(m_script) && (strPos + 1 < fmtStringLen))
 		{
 			fmtString[strPos] = '\0';
 			buttons[numButtons++] = fmtString + strPos + 1;
 		}
-		if (mb_length > 0)
-			mb_length--;
 
 	}
 

--- a/obse/obse/Commands_TextInput.cpp
+++ b/obse/obse/Commands_TextInput.cpp
@@ -8,6 +8,7 @@
 #include "FunctionScripts.h"
 #include <obse/Hooks_Input.h>
 #include <obse/Hooks_Input.h>
+#include <mbstring.h>
 
 enum {
 	kInputMenuType_Message,
@@ -267,15 +268,24 @@ void TextInputMessageBox::Init()
 	UInt32 fmtStringLen = strlen(m_fmtString);
 	char* fmtString = new char[fmtStringLen + 1];
 	strcpy_s(fmtString, fmtStringLen + 1, m_fmtString);
+	short mb_length = 0;
 
 	//separate prompt text and button text
 	for (UInt32 strPos = 0; strPos < fmtStringLen && numButtons < 10; strPos++)
 	{
-		if (fmtString[strPos] == GetSeparatorChar(m_script) && (strPos + 1 < fmtStringLen))
+		if (mb_length == 0) {
+			if (_mbsbtype((const unsigned char*)(fmtString + strPos), 1) == 2)		// get the length of a multibyte character from its first byte.
+				mb_length = _mbclen((const unsigned char*)(fmtString + strPos));
+		}
+
+		if (fmtString[strPos] == GetSeparatorChar(m_script) && (strPos + 1 < fmtStringLen) && mb_length == 0)
 		{
 			fmtString[strPos] = '\0';
 			buttons[numButtons++] = fmtString + strPos + 1;
 		}
+		if (mb_length > 0)
+			mb_length--;
+
 	}
 
 	m_promptText = fmtString;


### PR DESCRIPTION
These functions have an issue where a string will be separated at an unexpected position if it contains multibyte characters with the same charactor code as **SeparatorChar**.
The following is an example in the Japanized version Oblivion (Shift JIS):

> この'**弓**'を取りますか？ (Do you want to take this **bow**?)
↓
この'**弓**
'を取りますか？

In this example, the string is separated at an unexpected position because the character code for **弓** (bow) is _**0x8b7c**_, which contains **"_7c_"**, the character code for **SeparatorChar** (**|**).
