### PR TITLE
Add missing null check in ShowRuntimeError

### DIFF
--- a/obse/obse/ScriptUtils.cpp
+++ b/obse/obse/ScriptUtils.cpp
@@ -2843,7 +2843,7 @@ void ShowRuntimeError(Script* script, const char* fmt, ...)
 	char errorHeader[0x400];
 	// include mod filename, save having to ask users to figure it out themselves
 	const char* modName = "Savegame";
-	if (script->GetModIndex() != 0xFF)
+	if (script && script->GetModIndex() != 0xFF)
 	{
 		modName = (*g_dataHandler)->GetNthModName(script->GetModIndex());
 		if (!modName || !modName[0])


### PR DESCRIPTION
I initially only made the change to help me diagnose why oblivion was crashing, but It surprisingly completely fixed the crash I was trying to diagnose for me. (Probs mods spaghetti sauce issue, even tho it should be a me issue, I suppose it may fixes other crashes as well)

Pre-built binaries: [xOBSE_fox.zip](https://github.com/llde/xOBSE/files/14779526/xOBSE_fox.zip) ([VirusTotal scan](https://www.virustotal.com/gui/file/9ca87bdf96121d4a0c8d4ec4b9ee59516940f0086be04421d7630774b3d1da09) of zip)

I think this should be an easy merge, if anything needs to be changed, please tell me.