### PR TITLE
Correct default Steam path

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ If you use a desktop shortcut to launch Oblivion normally, just update the short
 
 IF YOU ARE USING THE STEAM VERSION OF OBLIVION:
 
-1. Copy obse_1_2_416.dll, obse_editor_1_2.dll, obse_steam_loader.dll and the Data folder  to your Oblivion directory. This is usually "C:\Program Files\Valve\Steam\SteamApps\common\oblivion".
+1. Copy obse_1_2_416.dll, obse_editor_1_2.dll, obse_steam_loader.dll and the Data folder  to your Oblivion directory. This is usually "C:\Program Files (x86)\Steam\steamapps\common\Oblivion".
 2. Launch Oblivion via Steam or by running Oblivion.exe. OBSE will automatically be run along with Oblivion when launched. To disable this, rename or move obse_steam_loader.dll. You do not need to use obse_loader.exe unless you are running the editor.
 
 IF USING STEAM PROTON ON LINUX (replace Point 2. from previous paragraph): 


### PR DESCRIPTION
Update the README with the correct default path to Oblivion in Steam installations.

The default path to Oblivion in Steam was not correct. Steam is located inside the 32-bit Program files folder and is not installed inside a Valve folder.