### PR TITLE
[POC] Access children of menu lists by listindex

### DIFF
--- a/obse/obse/GameTiles.cpp
+++ b/obse/obse/GameTiles.cpp
@@ -476,6 +476,32 @@ Tile::Value * Tile::GetValueByName(char* name)
 	return NULL;
 }
 
+Tile::Value * Tile::GetValueByNameAndListIndex(char* name, UInt32 listIndex)
+{
+	char* strtokContext = NULL;
+	char * childName = strtok_s(name, "\\/", &strtokContext);
+	char* nextName = NULL;
+	Tile * parentTile = this;
+
+	while (childName && parentTile)
+	{
+		nextName = strtok_s(NULL, "\\/", &strtokContext);
+		if (!nextName)
+		{
+			parentTile = parentTile->GetChildByListIndexTrait(listIndex);
+			break;
+		}
+	
+		parentTile = parentTile->GetChildByName(childName);
+		childName = nextName;
+	}
+
+	if (childName && !nextName && parentTile)	// childName is now name of value to retrieve
+		return parentTile->GetValueByType(StrToStrID(childName));
+
+	return NULL;
+}
+
 // this is currently very slow due to the # of tiles and values that need to be searched
 // The game probably caches the ID trait somewhere on the tile, investigate...
 Tile  * Tile::GetChildByIDTrait(UInt32 idToMatch)
@@ -494,6 +520,28 @@ Tile  * Tile::GetChildByIDTrait(UInt32 idToMatch)
 	// check this tile
 	Tile::Value* idVal = GetValueByType(kTileValue_id);
 	if (idVal && idVal->num == idToMatch)
+		return this;
+	else
+		return NULL;
+}
+
+// should only be used on tiles that have children with listindex trait
+Tile  * Tile::GetChildByListIndexTrait(UInt32 indexToMatch)
+{
+	// search children recursively
+	for (RefList::Node* node = childList.start; node; node = node->next)
+	{
+		if (node->data)
+		{
+			Tile* match = node->data->GetChildByListIndexTrait(indexToMatch);
+			if (match)
+				return match;
+		}
+	}
+
+	// check this tile
+	Tile::Value* idVal = GetValueByType(kTileValue_listindex);
+	if (idVal && idVal->num == indexToMatch)
 		return this;
 	else
 		return NULL;

--- a/obse/obse/GameTiles.h
+++ b/obse/obse/GameTiles.h
@@ -402,7 +402,9 @@ public:
 	Value * GetValueByName(char * name);
 //	bool	SetValueByName(char* name, const char* strVal, float floatVal);
 	Tile  * GetChildByName(const char * name);
+	Value * GetValueByNameAndListIndex(char * name, UInt32 indexToMatch);
 	Tile  * GetChildByIDTrait(UInt32 idToMatch);	// find child with <id> trait matching idToMatch
+	Tile  * GetChildByListIndexTrait(UInt32 indexToMatch); // find child with <listindex> trait matching indexToMatch
 	bool GetFloatValue(UInt32 valueType, float* out);
 	bool SetFloatValue(UInt32 valueType, float newValue);
 	bool GetStringValue(UInt32 valueType, const char** out);


### PR DESCRIPTION
In this PR it's now possible to access children of menu lists. The syntax should be compatible with already existing commands.

To access the chidren a one should specify:

1. a list container full ui path (not a path to a children)
2. `|<listindex>`, e.g. `parent\path\user0|25`

In the current draft implementation `ClickMenuButton` is not yet updated, but it's possible to get an ID of a children and click it, Sample:

```
  let path := "rep_contents\rep_list_pane"
  let listindex := 0
  let pathId := sv_Construct "%z\id|%0.f" path listindex
  let i := GetMenuFloatValue $pathId 1035 ; get item ID
  let pathClick := sv_Construct "#%0.f" i
  ClickMenuButton $pathClick 1035
  
  sv_Destruct pathId pathClick
```

To test, install MenuControlsModernized attached to this PR, open a repair menu, and click "R".

Build release version of xOBSE: [obse-build.zip](https://github.com/user-attachments/files/20361923/obse-build.zip)
Mod that uses new feature: [MenuControlsModernized_1.12.1_xOBSE_Fork_0.0.1.zip](https://github.com/user-attachments/files/20362026/MenuControlsModernized_1.12.1_xOBSE_Fork_0.0.1.zip)
