### PR TITLE
Allow accessing children of a menu list by listindex

### DIFF
--- a/obse/obse/GameTiles.cpp
+++ b/obse/obse/GameTiles.cpp
@@ -1,6 +1,5 @@
 #include "GameTiles.h"
 #include "GameAPI.h"
-#include <limits.h>
 #include <string>
 
 #if 0
@@ -461,7 +460,7 @@ Tile * Tile::GetChildByPath(char* path, bool isTrait, char** outTraitName)
 	char* childName = strtok_s(path, "\\/", &strtokContext);
 	char* nextName = NULL;
 	Tile* parentTile = this;
-	int listIndex = INT_MIN;
+	int listIndex = -1;
 
 	while (childName && parentTile)
 	{
@@ -469,10 +468,10 @@ Tile * Tile::GetChildByPath(char* path, bool isTrait, char** outTraitName)
 		if (!nextName)
 			break;
 	
-		if (listIndex > INT_MIN)
+		if (listIndex >= 0)
 		{
 			parentTile = parentTile->GetChildByListIndexTrait(listIndex);
-			listIndex = INT_MIN;
+			listIndex = -1;
 		}
 		else
 		{
@@ -496,7 +495,7 @@ Tile * Tile::GetChildByPath(char* path, bool isTrait, char** outTraitName)
 			return parentTile;
 		}
 
-		return listIndex == INT_MIN
+		return listIndex < 0
 			? parentTile->GetChildByName(childName)
 			: parentTile->GetChildByListIndexTrait(listIndex);
 	}

--- a/obse/obse/GameTiles.cpp
+++ b/obse/obse/GameTiles.cpp
@@ -455,7 +455,7 @@ Tile * Tile::GetChildByName(const char * name)
 	return requestedTile;
 }
 
-Tile * Tile::GetChildByPath(char * path, bool isTrait, char** outTraitName)
+Tile * Tile::GetChildByPath(char* path, bool isTrait, char** outTraitName)
 {
 	char* strtokContext = NULL;
 	char* childName = strtok_s(path, "\\/", &strtokContext);

--- a/obse/obse/GameTiles.cpp
+++ b/obse/obse/GameTiles.cpp
@@ -541,19 +541,13 @@ Tile  * Tile::GetChildByIDTrait(UInt32 idToMatch)
 // should only be used on tiles that have children with listindex trait
 Tile  * Tile::GetChildByListIndexTrait(UInt32 indexToMatch)
 {
-	// check this tile
-	Tile::Value* idVal = GetValueByType(kTileValue_listindex);
-	if (idVal && idVal->num == indexToMatch)
-		return this;
-
-	// search children recursively
 	for (RefList::Node* node = childList.start; node; node = node->next)
 	{
 		if (node->data)
 		{
-			Tile* match = node->data->GetChildByListIndexTrait(indexToMatch);
-			if (match)
-				return match;
+			Tile::Value* idVal = node->data->GetValueByType(kTileValue_listindex);
+			if (idVal && idVal->num == indexToMatch)
+				return node->data;
 		}
 	}
 

--- a/obse/obse/GameTiles.cpp
+++ b/obse/obse/GameTiles.cpp
@@ -225,7 +225,7 @@ typedef const char * (* _TileStrIDToStr)(UInt32 ID);
 
 const _TileStrToStrID TileStrToStrID = (_TileStrToStrID)0x00588EF0;
 const _TileStrIDToStr TileStrIDToStr = (_TileStrIDToStr)0x00589080;
-const char* _ListIndexSeparator = ":";
+const char* ListIndexSeparator = ":";
 
 
 UInt32 Tile::StrToStrID(const char * str)
@@ -479,7 +479,7 @@ Tile * Tile::GetChildByPath(char* path, bool isTrait, char** outTraitName)
 			parentTile = parentTile->GetChildByName(childName);
 		}
 
-		if (nextName[0] == _ListIndexSeparator[0])
+		if (nextName[0] == ListIndexSeparator[0])
 		{
 			nextName = nextName + 1;
 			listIndex = atoi(nextName);

--- a/obse/obse/GameTiles.h
+++ b/obse/obse/GameTiles.h
@@ -402,7 +402,9 @@ public:
 	Value * GetValueByName(char * name);
 //	bool	SetValueByName(char* name, const char* strVal, float floatVal);
 	Tile  * GetChildByName(const char * name);
+	Tile  * GetChildByPath(char* path, bool isTrait = false, char** outTraitName = NULL);
 	Tile  * GetChildByIDTrait(UInt32 idToMatch);	// find child with <id> trait matching idToMatch
+	Tile  * GetChildByListIndexTrait(UInt32 indexToMatch); // find child with <listindex> trait matching indexToMatch
 	bool GetFloatValue(UInt32 valueType, float* out);
 	bool SetFloatValue(UInt32 valueType, float newValue);
 	bool GetStringValue(UInt32 valueType, const char** out);

--- a/obse_command_doc.html
+++ b/obse_command_doc.html
@@ -136,6 +136,9 @@
 
 	background-color: #ffffff;
 	}
+	.no-margin-left {
+		margin-left: 0px!important;
+	}
 	/* code syntax in descriptive text */
 	code {
 
@@ -5270,17 +5273,47 @@ Message: The formID of the reference whose attached script generated the message
 	; clicks the icon for the player's active spell, switching from item view to spell view if inventory is open
 	ClickMenuButton "hudmain_background\hudmain_magic_cover" 1009</pre>
 
+<p>There is an exception for working with children of a list, though. To access a child of a list by its listindex a one should use the following syntax:</p>
+<p><code class="s">GetMenuFloatValue "path\to\list\:listindex\trait" menuCode</code></p>
+<p>
+	For example, to access <code class="s no-margin-left">user5</code> trait of children of a repair menu from 1 to 3:
+	<pre>
+		let itemHealth1 := GetMenuFloatValue "rep_contents\rep_list_pane\:0\user5" 1035
+		let itemHealth2 := GetMenuFloatValue "rep_contents\rep_list_pane\:1\user5" 1035
+		let itemHealth3 := GetMenuFloatValue "rep_contents\rep_list_pane\:2\user5" 1035
+	</pre>
+</p>
+<p>Additonal notes for working with children of a list:
+	<ol>
+		<li>This syntax should only be used to access chidren of a list, for other tiles it may behave unexpectedly</li>
+		<li>This syntax also allows to acces children of a list children, i.e.: <code class="s no-margin-left">GetMenuFloatValue "path\to\list\:listindex\child\trait" menuCode</code></li>
+		<li>The same is applicable to all functions that allow to access/set traits of a menu tile</li>
+	</ol>
+</p>
+
 <p><a id="GetMenuFloatValue" class="f" href="https://cs.uesp.net/wiki/GetMenuFloatValue">GetMenuFloatValue</a> - returns the value of a float or boolean trait of the specified menu<br />
 <code class="s">(value:float) GetMenuFloatValue trait:<a href="#Format_Specifiers">formatString</a> <a href="#Menu_Code">menuType</a>:int</code></p>
+<p>
+	To get a value for a children of a list, use the following syntax:<br><code class="s">GetMenuFloatValue "path\to\list\:listindex\trait" menuType</code>
+</p>
 
 <p><a id="GetMenuStringValue" class="f" href="https://cs.uesp.net/wiki/GetMenuStringValue">GetMenuStringValue</a> - returns the value of a string trait of the specified menu<br />
 <code class="s">(value:string_var) GetMenuStringValue trait:<a href="#Format_Specifiers">formatString</a> <a href="#Menu_Code">menuType</a>:int</code></p>
+<p>
+	To get a value for a children of a list, use the following syntax:<br><code class="s">GetMenuStringValue "path\to\list\:listindex\trait" menuType</code>
+</p>
 
 <p><a id="SetMenuFloatValue" class="f" href="https://cs.uesp.net/wiki/SetMenuFloatValue">SetMenuFloatValue</a> - sets the value of a float or boolean trait of the specified menu<br />
 <code class="s">(nothing) SetMenuFloatValue trait:<a href="#Format_Specifiers">formatString</a> <a href="#Menu_Code">menuType</a>:intnewValue:float</code></p>
+<p>
+	To set a value for a children of a list, use the following syntax:<br><code class="s">SetMenuFloatValue "path\to\list\:listindex\trait" menuType</code>
+</p>
 
 <p><a id="SetMenuStringValue" class="f" href="https://cs.uesp.net/wiki/SetMenuStringValue">SetMenuStringValue</a> - sets the value of a string trait of the specified menu. The new value follows the trait name, separated from it by a pipe character. i.e. "elementName\traitName|newValue". (If calling from the console, replace the pipe character with the '@' character).<br />
 <code class="s">(nothing) SetMenuStringValue traitAndNewValue:<a href="#Format_Specifiers">formatString</a> <a href="#Menu_Code">menuType</a>:int</code></p>
+<p>
+	To set a value for a children of a list, use the following syntax:<br><code class="s">SetMenuStringValue "path\to\list\:listindex\trait|newValue" menuType</code>
+</p>
 
 <p><a id="GetActiveUIComponentID" class="f" href="https://cs.uesp.net/wiki/GetActiveUIComponentID">GetActiveUIComponentID</a> - returns the integer ID of the menu elemented currently highlighted by the mouse cursor as defined by that element's &lt;id&gt; trait in the menu XML file.<br />
 <code class="s">(id:int) GetActiveMenuComponentID</code></p>
@@ -5293,9 +5326,15 @@ Message: The formID of the reference whose attached script generated the message
 
 <p><a id="ClickMenuButton" class="f" href="https://cs.uesp.net/wiki/ClickMenuButton">ClickMenuButton</a> - simulates the user clicking on the specified UI component. Pass the fully qualified component name as described above, or pass the &lt;id&gt; trait of the desired component as specified in the XML, preceded by a '#'; i.e. "<code>#32</code>" to click the button with ID 32. Note that specifying the name results in much better performance than specifying an ID.<br />
 <code class="s">(nothing) ClickMenuButton componentName:<a href="#Format_Specifiers">formatString</a> <a href="#Menu_Code">menuType</a>:int</code></p>
+<p>
+	To click a children of a list, use the following syntax:<br><code class="s">ClickMenuButton "path\to\list\:listindex" menuType</code>
+</p>
 
 <p><a id="GetMenuHasTrait" class="f" href="https://cs.uesp.net/wiki/GetMenuHasTrait">GetMenuHasTrait</a> - returns 1 if the menu has the trait specified. The trait name may be qualified with component names to access traits of subcomponents.<br />
 <code class="s">(hasTrait:bool) GetMenuHasTrait traitName:<a href="#Format_Specifiers">formatString</a> <a href="#Menu_Code">menuType</a>:int</code></p>
+<p>
+	To check if a children of a list has the trait, use the following syntax:<br><code class="s">GetMenuHasTrait "path\to\list\:listindex\trait" menuType</code>
+</p>
 
 <p><a id="GetTileChildren" class="f" href="https://cs.uesp.net/wiki/GetTileChildren">GetTileChildren</a> - given a UI component (referred to by the game as a "Tile"), returns an Array containing the names of all of the direct subcomponents of that component. Using this command is more efficient than accessing children individually if you need to inspect more than one subcomponent.<br />
 <code class="s">(children:Array) GetTileChildren parentTile:string menuType:int</code></p>

--- a/obse_command_doc.html
+++ b/obse_command_doc.html
@@ -5286,7 +5286,7 @@ Message: The formID of the reference whose attached script generated the message
 <p>Additonal notes for working with children of a list:
 	<ol>
 		<li>This syntax should only be used to access chidren of a list, for other tiles it may behave unexpectedly</li>
-		<li>This syntax also allows to acces children of a list children, i.e.: <code class="s no-margin-left">GetMenuFloatValue "path\to\list\:listindex\child\trait" menuCode</code></li>
+		<li>This syntax also allows to access children of a list children, i.e.: <code class="s no-margin-left">GetMenuFloatValue "path\to\list\:listindex\child\trait" menuCode</code></li>
 		<li>The same is applicable to all functions that allow to access/set traits of a menu tile</li>
 	</ol>
 </p>


### PR DESCRIPTION
Notes:
- compatible with existing syntax
- new syntax: `path/to/list/:listindex/children`

Mod that uses a new syntax: 
[MenuControlsModernized_1.2.1_xOBSE_Fork_0.0.4.zip](https://github.com/user-attachments/files/20637651/MenuControlsModernized_1.12.1_xOBSE_Fork_0.0.4.zip)

Sample:

```
let itemHealth1 := GetMenuFloatValue "rep_contents\rep_list_pane\:0\user5" 1035
SetMenuStringValue "rep_contents\rep_list_pane\:0\user4|newName" 1035
ClickMenuButton "rep_contents\rep_list_pane\:0" 1035
```

Previous syntax proposal that does not allow access children of a list children: [PR#246](https://github.com/llde/xOBSE/pull/246)